### PR TITLE
Fix influx handler config

### DIFF
--- a/migration/files/sensu/conf.d/cpu_percentage.json
+++ b/migration/files/sensu/conf.d/cpu_percentage.json
@@ -8,7 +8,7 @@
       ],
       "interval": 10,
       "handlers": [
-        "influxdb-tcp"
+        "influx-tcp"
       ]
     }
   }

--- a/migration/files/sensu/conf.d/influxdb.json
+++ b/migration/files/sensu/conf.d/influxdb.json
@@ -16,6 +16,6 @@
         "retry"         : null,
         "prefix"        : "",
         "denormalize"   : true,
-        "status"        : true
+        "status"        : false
     }
 }


### PR DESCRIPTION
- Fix the influx handler name in the check name to match our configured handler
- The influx handler should not use the check status code as the metric